### PR TITLE
Use sysctl.d config and system reload

### DIFF
--- a/Install/tweaker.sh
+++ b/Install/tweaker.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 tput setaf 7 ; tput setab 4 ; tput bold ; printf '%35s%s%-20s\n' "TCP Tweaker 1.0" ; tput sgr0
-if [[ `grep -c "^#PH56" /etc/sysctl.conf` -eq 1 ]]
+SYSCTL_CONF="/etc/sysctl.d/99-vpn-optimizer.conf"
+
+mkdir -p /etc/sysctl.d
+touch "$SYSCTL_CONF"
+
+if [[ `grep -c "^#PH56" "$SYSCTL_CONF"` -eq 1 ]]
 then
-	echo ""
-	echo "TCP Tweaker network settings have already been added to the system!"
+        echo ""
+        echo "TCP Tweaker network settings have already been added to the system!"
 	echo ""
 	read -p "Do you want to remove TCP Tweaker settings? [y/n]: " -e -i n resposta0
 	if [[ "$resposta0" = 'y' ]]; then
@@ -14,8 +19,8 @@ net.core.wmem_max = 16777216
 net.ipv4.tcp_rmem = 4096 87380 16777216
 net.ipv4.tcp_wmem = 4096 16384 16777216
 net.ipv4.tcp_low_latency = 1
-net.ipv4.tcp_slow_start_after_idle = 0" /etc/sysctl.conf > /tmp/syscl && mv /tmp/syscl /etc/sysctl.conf
-sysctl -p /etc/sysctl.conf > /dev/null
+net.ipv4.tcp_slow_start_after_idle = 0" "$SYSCTL_CONF" > /tmp/syscl && mv /tmp/syscl "$SYSCTL_CONF"
+sysctl --system > /dev/null
 		echo ""
 		echo "TCP Tweaker network settings were successfully removed."
 		echo ""
@@ -32,19 +37,19 @@ else
 	echo ""
 	read -p "Proceed with installation? [y/n]: " -e -i n resposta
 	if [[ "$resposta" = 'y' ]]; then
-	echo ""
-	echo "Modifying the following settings:"
-	echo " " >> /etc/sysctl.conf
-	echo "#PH56" >> /etc/sysctl.conf
+        echo ""
+        echo "Modifying the following settings:"
+        echo " " >> "$SYSCTL_CONF"
+        echo "#PH56" >> "$SYSCTL_CONF"
 echo "net.ipv4.tcp_window_scaling = 1
 net.core.rmem_max = 16777216
 net.core.wmem_max = 16777216
 net.ipv4.tcp_rmem = 4096 87380 16777216
 net.ipv4.tcp_wmem = 4096 16384 16777216
 net.ipv4.tcp_low_latency = 1
-net.ipv4.tcp_slow_start_after_idle = 0" >> /etc/sysctl.conf
+net.ipv4.tcp_slow_start_after_idle = 0" >> "$SYSCTL_CONF"
 echo ""
-sysctl -p /etc/sysctl.conf
+sysctl --system
 		echo ""
 		echo "TCP Tweaker network settings have been added successfully."
 		echo ""

--- a/bbrv3.sh
+++ b/bbrv3.sh
@@ -25,6 +25,11 @@ RED="\e[91m"
 BLUE="\e[94m"
 MAGENTA="\e[95m"
 NC="\e[0m"
+SYSCTL_CONF="/etc/sysctl.d/99-vpn-optimizer.conf"
+SYSCTL_BACKUP="${SYSCTL_CONF}.bak"
+
+mkdir -p /etc/sysctl.d
+touch "$SYSCTL_CONF"
 
 ask_reboot() {
 echo ""
@@ -237,10 +242,10 @@ bbrv3() {
         y|Y)
             clear
             echo -e "${YELLOW}Backing up original kernel parameter configuration... ${NC}"
-            cp /etc/sysctl.conf /etc/sysctl.conf.bak
+            cp "$SYSCTL_CONF" "$SYSCTL_BACKUP"
             echo -e "${YELLOW}Optimizing kernel parameters for better network performance... ${NC}"
 
-            cat <<EOL >> /etc/sysctl.conf
+            cat <<EOL >> "$SYSCTL_CONF"
 # BBRv3 Optimization for Better Network Performance
 net.ipv4.tcp_timestamps = 1
 net.ipv4.tcp_sack = 1
@@ -252,12 +257,12 @@ net.ipv4.tcp_wmem = 4096 65536 16777216
 net.ipv4.tcp_congestion_control = bbr
 EOL
 
-            sysctl -p
+            sysctl --system
             if [ $? -eq 0 ]; then
                 echo -e "${GREEN}Kernel parameter optimization for better network performance was successful.${NC}"
             else
                 echo -e "${RED}Kernel parameter optimization failed. Restoring the original configuration...${NC}"
-                mv /etc/sysctl.conf.bak /etc/sysctl.conf
+                mv "$SYSCTL_BACKUP" "$SYSCTL_CONF"
             fi
             ;;
         n|N)

--- a/centos.md
+++ b/centos.md
@@ -35,7 +35,7 @@ ulimit -n 51200
 ```
 دستور زیر را اجرا کنید:
 ```
-nano /etc/sysctl.conf
+nano /etc/sysctl.d/99-vpn-optimizer.conf
 ```
 خطوط زیر را در انتهای فایل اضافه کنید:
 


### PR DESCRIPTION
## Summary
- update scripts to manage kernel tuning in /etc/sysctl.d/99-vpn-optimizer.conf instead of /etc/sysctl.conf
- reload kernel parameters with `sysctl --system`, ensuring the sysctl.d file exists and is backed up where needed
- refresh documentation to reference the new sysctl configuration path

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6930fb9c8bf8833097596fad2ebcfb79)