### PR TITLE
Add Marzban node install option

### DIFF
--- a/optimizer.sh
+++ b/optimizer.sh
@@ -1068,6 +1068,7 @@ while true; do
     printf "${GREEN} 10) ${NC}DNS Test V6 ${NC}\n"
     printf "${GREEN} 11) ${NC} Optimize Network ${NC}\n"
     printf "${GREEN} 12) ${NC} Abuse Defender ${NC}\n"
+    printf "${GREEN} 13) ${NC} Marzban Node Install ${NC}\n"
     echo && echo -e "\e[93m+-----------------------------------------------+\e[0m"
     echo && printf "${GREEN} E) ${NC} Exit the menu${NC}\n"
     echo && echo -ne "${GREEN}Select an option: ${NC}"
@@ -1126,6 +1127,9 @@ while true; do
             ;;
         12)
             bash <(curl -s https://raw.githubusercontent.com/Kiya6955/Abuse-Defender/main/abuse-defender.sh)
+            ;;
+        13)
+            bash -c "$(curl -sL https://github.com/xmohammad1/Marzban-scripts/raw/master/marzban-node.sh)" @ install
             ;;
         E|e)
             echo && echo -e "$RED Exiting...$NC"


### PR DESCRIPTION
## Summary
- add a new menu option to launch the Marzban node installation script from the optimizer menu

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693bf743b0a08330b679f96763066445)